### PR TITLE
added update item positions method for the case of removing item.

### DIFF
--- a/src/list_view_core.js
+++ b/src/list_view_core.js
@@ -62,6 +62,21 @@ export default class ListViewCore {
     return child;
   }
 
+  updateItemsPosition() {
+    this.items.forEach((child, i) => {
+      let xy = 0;
+      if (i > 0) {
+        let lastChild = this.grp.getChildAt(i - 1);
+        xy =
+          lastChild[this.p.xy] +
+          getWidthOrHeight(lastChild, this.p.wh) +
+          this.o.padding;
+      }
+      child[this.p.xy] = xy;
+      this.length = xy + child[this.p.wh];
+    }); 
+  }
+
   /**
    * [addMultiple children to the list]
    * @param {...[DisplayObjects]} children


### PR DESCRIPTION
when I remove item with "remove" method, list item's position was not changed.
to solve this issue, I added the new method to update items position.

I didn't add this method inside "remove" method in case of the unexpected implementation, 

how to use
1. remove an item from a list
2. call "updateItemsPosition" method to update positions of all items
